### PR TITLE
Add additional parameter for Customizing and remove warning reason

### DIFF
--- a/lib/flutter_time_picker_spinner.dart
+++ b/lib/flutter_time_picker_spinner.dart
@@ -421,7 +421,7 @@ class _TimePickerSpinnerState extends State<TimePickerSpinner> {
       },
       child: ListView.builder(
         itemBuilder: (context, index) {
-          String text = index == 1 ? (widget.apNames![index] ?? 'AM') : (index == 2 ? (widget.apNames![index] ?? 'PM') : '');
+          String text = index == 1 ? (widget.apNames![index-1] ?? 'AM') : (index == 2 ? (widget.apNames![index-1] ?? 'PM') : '');
           return Container(
             height: _getItemHeight(),
             alignment: Alignment.center,

--- a/lib/flutter_time_picker_spinner.dart
+++ b/lib/flutter_time_picker_spinner.dart
@@ -1,3 +1,5 @@
+// Modeified by SehunKIM 2023.01.08
+
 library time_picker_spinner;
 
 import 'package:flutter/material.dart';

--- a/lib/flutter_time_picker_spinner.dart
+++ b/lib/flutter_time_picker_spinner.dart
@@ -78,6 +78,7 @@ class TimePickerSpinner extends StatefulWidget {
   final AlignmentGeometry? alignment;
   final double? spacing;
   final bool isForce2Digits;
+  final List? apNames;
   final TimePickerCallback? onTimeChange;
 
   TimePickerSpinner(
@@ -94,6 +95,7 @@ class TimePickerSpinner extends StatefulWidget {
       this.alignment,
       this.spacing,
       this.isForce2Digits = false,
+      this.apNames,
       this.onTimeChange})
       : super(key: key);
 
@@ -419,7 +421,7 @@ class _TimePickerSpinnerState extends State<TimePickerSpinner> {
       },
       child: ListView.builder(
         itemBuilder: (context, index) {
-          String text = index == 1 ? 'AM' : (index == 2 ? 'PM' : '');
+          String text = index == 1 ? (widget.apNames![index] ?? 'AM') : (index == 2 ? (widget.apNames![index] ?? 'PM') : '');
           return Container(
             height: _getItemHeight(),
             alignment: Alignment.center,

--- a/lib/flutter_time_picker_spinner.dart
+++ b/lib/flutter_time_picker_spinner.dart
@@ -222,8 +222,7 @@ class _TimePickerSpinnerState extends State<TimePickerSpinner> {
     super.initState();
 
     if (widget.onTimeChange != null) {
-      WidgetsBinding.instance!
-          .addPostFrameCallback((_) => widget.onTimeChange!(getDateTime()));
+      WidgetsBinding.instance.addPostFrameCallback((_) => widget.onTimeChange!(getDateTime()));
     }
   }
 

--- a/lib/flutter_time_picker_spinner.dart
+++ b/lib/flutter_time_picker_spinner.dart
@@ -79,6 +79,7 @@ class TimePickerSpinner extends StatefulWidget {
   final double? spacing;
   final bool isForce2Digits;
   final List? apNames;
+  final String apPosition;
   final TimePickerCallback? onTimeChange;
 
   TimePickerSpinner(
@@ -96,6 +97,7 @@ class TimePickerSpinner extends StatefulWidget {
       this.spacing,
       this.isForce2Digits = false,
       this.apNames,
+      this.apPosition = 'right',
       this.onTimeChange})
       : super(key: key);
 
@@ -285,12 +287,22 @@ class _TimePickerSpinnerState extends State<TimePickerSpinner> {
     }
 
     if (!widget.is24HourMode) {
-      contents.add(spacer());
-      contents.add(SizedBox(
-        width: _getItemWidth()! * 1.2,
-        height: _getItemHeight()! * 3,
-        child: apSpinner(),
-      ));
+      if(widget.apPosition=='right'){
+        contents.add(spacer());
+        contents.add(SizedBox(
+          width: _getItemWidth()! * 1.2,
+          height: _getItemHeight()! * 3,
+          child: apSpinner(),
+        ));
+      }
+      else if(widget.apPosition=='left'){
+        contents.insert(0, spacer());
+        contents.insert(0, SizedBox(
+          width: _getItemWidth()! * 1.2,
+          height: _getItemHeight()! * 3,
+          child: apSpinner(),
+        ));
+      }
     }
 
     return Row(


### PR DESCRIPTION
1. Add apNames parameter for using custom apSpinner's words.
2. Add apPosition parameter for change position of apSpinner
3. "!" operand  raise warning. So I modified a line of code to remove the warning "Operand  of null-aware operation '!' has type 'WidgetsBinding' which excludes null." 