### PR TITLE
Update flutter_time_picker_spinner.dart

### DIFF
--- a/lib/flutter_time_picker_spinner.dart
+++ b/lib/flutter_time_picker_spinner.dart
@@ -363,14 +363,14 @@ class _TimePickerSpinnerState extends State<TimePickerSpinner> {
               text == '0') {
             text = '12';
           }
-          if (widget.isForce2Digits && text != '') {
-            text = text.padLeft(2, '0');
-          }
+          // if (widget.isForce2Digits && text != '') {
+          //   text = text.padLeft(2, '0');
+          // }
           return Container(
             height: _getItemHeight(),
             alignment: _getAlignment(),
             child: Text(
-              text,
+              text.padLeft(2, '0'),
               style: selectedIndex == index
                   ? _getHighlightedTextStyle()
                   : _getNormalTextStyle(),


### PR DESCRIPTION
Current version of flutter is not allowing us to show time in 2 digits(i-e 00, 02, 04, 09). Few modifications are done in it, which makes it working exactly fine now. 