### PR TITLE
Update flutter_time_picker_spinner.dart

### DIFF
--- a/lib/flutter_time_picker_spinner.dart
+++ b/lib/flutter_time_picker_spinner.dart
@@ -422,7 +422,7 @@ class _TimePickerSpinnerState extends State<TimePickerSpinner> {
           String text = index == 1 ? 'AM' : (index == 2 ? 'PM' : '');
           return Container(
             height: _getItemHeight(),
-            alignment: Alignment.center,
+            alignment: _getAlignment(),
             child: Text(
               text,
               style: currentSelectedAPIndex == index


### PR DESCRIPTION
updated "AM"/"PM" spinner text's alignment from center alignment to the alignment returned by "_getAlignment()", which is same as alignment of hours/minutes/seconds